### PR TITLE
Quote the ansible platforms so they're strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,21 @@ Now you can setup your virtual environment for testing:
 ```bash
 virtualenv --python=$(which python2.7) .venv
 source .venv/bin/activate
-pip install -r test-requirements.txt
+pip install -r --no-deps test-requirements.txt
 ```
 
-Use `molecule` commands for testing.
+Run the full test suite against the default platform. The default platform is
+`sierra`:
+
+```bash
+molecule test
+```
+
+Run the full test suite on a different platform:
+
+```bash
+molecule test --platform yosemite
+```
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,9 +9,9 @@ galaxy_info:
   platforms:
     - name: MacOSX
       versions:
-        - 10.12
-        - 10.11
-        - 10.10
+        - '10.12'
+        - '10.11'
+        - '10.10'
 
   galaxy_tags:
     - command


### PR DESCRIPTION
This change also adds additional testing instructions for using
molecule against multiple versions of OS X.