### PR TITLE
File module shouldn't set recurse if state=absent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
   file:
     path: '{{ clt_path }}'
     state: absent
-    recurse: true
   when: force_install
   become: yes
 


### PR DESCRIPTION
If no update is available for the command line tools, then
softwareupdate will return 0 but log a message to stderr, not stdout.
In order to check if the task actually failed, we should look at
either the error code, or see if both stderr and stdout were empty.

This PR also contains a minor bugfix for another problem that I found while testing this issue.

Fixes https://github.com/elliotweiser/ansible-osx-command-line-tools/issues/12