### PR TITLE
Add prepare.yml to default Molecule scenario

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  tasks:
+    - name: Nothing to prepare
+      debug:
+        msg: Nothing to do! Moving on...


### PR DESCRIPTION
This suppresses the deprecation warning when testing w/ Molecule.