### PR TITLE
Fix a bad test

### DIFF
--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -2,8 +2,8 @@ import re
 
 
 def test_tmp_file_is_gone(host):
-    tmp_file = 'tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
-    f = host.file(tmp_file)
+    tmpfile = '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    f = host.file(tmpfile)
     assert not f.exists
 
 


### PR DESCRIPTION
The test for the Command Line Tools tmp file was looking at the
wrong path. It was missing a leading slash.