### PR TITLE
Preparing for 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ None (except running on Mac OS X).
 Role Variables
 --------------
 
-`force_install`: Install the Command Line Tools, even if they are already installed (Default: `no`).
+Going forward, all role variables will be prefixed with `clt_` (for **C**ommand
+**L**ine **T**ools) to avoid ambiguity and namespace collision.
+
+| Variable Name                        | Description                                                               | Default |
+| :---                                 | :---                                                                      |  :---:  |
+| `clt_force_install`                  | Install the Command Line Tools, even if already installed                 |  `no`   |
+| `clt_softwareupdate_list_timeout`    | How long (in seconds) to wait for an available Command Line Tools package |  `300`  |
+| `clt_softwareupdate_install_timeout` | How long (in seconds) to wait for installation of the Command Line Tools  |  `1200` |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 # defaults file for ansible-osx-command-line-tools
 
-force_install: no
+clt_force_install: no
+clt_softwareupdate_list_timeout: 300
+clt_softwareupdate_install_timeout: 1200

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,2 @@
 ---
 # handlers file for ansible-osx-command-line-tools
-
-- name: Cleanup
-  file:
-    path: /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-    state: absent

--- a/tasks/install_clt.yml
+++ b/tasks/install_clt.yml
@@ -1,0 +1,46 @@
+---
+# Tasks for performing the installation of the Command Line Tools
+
+- name: Touch tmp file
+  file: path={{ clt_tmp_file }} state=touch
+
+- name: Check for Command Line Tools in Software Update list
+  shell: >
+    /usr/sbin/softwareupdate -l |
+    grep -B 1 -E 'Command Line Tools' |
+    awk -F'*' '/^ +\*/ {print $2}' |
+    sed 's/^ *//' |
+    head -n1
+  register: su_list
+  async: '{{ clt_softwareupdate_list_timeout }}'
+  poll: 0
+  changed_when: false
+
+- name: Wait for softwareupdate list to finish
+  async_status: jid={{ su_list.ansible_job_id }}
+  register: su_list_results
+  failed_when: >-
+    'rc' in su_list_results and su_list_results.rc != 0 or
+    'stdout' in su_list_results and su_list_results.stdout|length == 0
+  until: su_list_results.finished
+  retries: >-
+    {{ (clt_softwareupdate_list_timeout / 10) | round(0, "ceil") | int }}
+  delay: 10
+
+- name: Install Command Line Tools via Software Update
+  command: /usr/sbin/softwareupdate -i '{{ su_list_results.stdout }}'
+  register: su_install
+  async: '{{ clt_softwareupdate_install_timeout }}'
+  poll: 0
+  changed_when: false
+
+- name: Wait for softwareupdate install to finish
+  async_status: jid={{ su_install.ansible_job_id }}
+  register: su_install_results
+  until: su_install_results.finished
+  retries: >-
+    {{ (clt_softwareupdate_install_timeout / 10) | round(0, "ceil") | int }}
+  delay: 10
+
+- name: Cleanup tmp file
+  file: path={{ clt_tmp_file }} state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,15 @@
 # tasks file for ansible-osx-command-line-tools
 
 - name: Am I running on Mac OS X?
-  fail:
+  assert:
+    that: ansible_distribution == 'MacOSX'
     msg: Target host is not running Mac OS X
-  when: ansible_distribution != 'MacOSX'
 
 - name: Remove existing Command Line Tools installation
   file:
     path: '{{ clt_path }}'
     state: absent
-  when: force_install
+  when: clt_force_install
   become: yes
 
 - name: Check that the Command Line Tools path is present
@@ -32,26 +32,6 @@
   ignore_errors: true
   changed_when: false
 
-- name: Prepare to install Command Line Tools
-  file:
-    path: /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-    state: touch
+- name: Install if Command Line Tools detection failed
+  include_tasks: install_clt.yml
   when: pkg_info.rc != 0 or compiler.rc != 0 or not clt.stat.exists
-
-- name: Check for Command Line Tools in Software Update list
-  shell: >
-    softwareupdate -l |
-    grep -B 1 -E 'Command Line Tools' |
-    awk -F'*' '/^ +\*/ {print $2}' |
-    sed 's/^ *//' |
-    head -n1
-  register: su_list
-  when: pkg_info.rc != 0 or compiler.rc != 0 or not clt.stat.exists
-  changed_when: false
-  failed_when: su_list.rc != 0 or su_list.stdout|length == 0
-
-- name: Install Command Line Tools
-  command: softwareupdate -i '{{ su_list.stdout }}'
-  when: pkg_info.rc != 0 or compiler.rc != 0 or not clt.stat.exists
-  notify:
-    - Cleanup

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,4 @@
 # vars file for ansible-osx-command-line-tools
 
 clt_path: /Library/Developer/CommandLineTools
+clt_tmp_file: /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress


### PR DESCRIPTION
New Features
------------

Users can now define a timeout value for waiting for
`softwareupdate` operations to complete. By default, the role will
wait up to 5 minutes to check for updates and 20 minutes to install
the Command Line Tools package. This is generous, but it provides
some wiggle room for slow/Wi-Fi internet connections. Users can
enforce a faster installation time by reducing those values.
This feature relates to #18 and will prevent the installation
from getting stuck for too long. This is not a true fix, but
will at least save time for certain users/use-cases.

Breaking Changes
----------------

The `force_install` variable was renamed to `clt_force_install`.
The README explains the reasoning behind the prefix.

Summary of Changes
------------------

* Move installation tasks to separate file
* Detection of `ansible_distribution` is now an `assert`ion.
* Add Command Line Tools tmp file path to vars
* Move handlers to tasks (`include_tasks` in handlers obscures names)
* Asynchronously run `softwareupdate` and poll for completion
* Update README with new default vars