### PR TITLE
Support OS X 10.13 (High Sierra)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,29 @@
 ---
 sudo: required
 language: generic
-os: osx
-env:
-  - OSX_IMAGE=xcode9.2 ANSIBLE_VERSION=2.4.3.0
-  - OSX_IMAGE=xcode9.2 ANSIBLE_VERSION=2.3.3.0
-  - OSX_IMAGE=xcode9.2 ANSIBLE_VERSION=2.2.3.0
-  - OSX_IMAGE=xcode8.3 ANSIBLE_VERSION=2.4.3.0
-  - OSX_IMAGE=xcode7.3 ANSIBLE_VERSION=2.4.3.0
-  - OSX_IMAGE=xcode6.4 ANSIBLE_VERSION=2.4.3.0
-
-osx_image: $OSX_IMAGE
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.3beta
+      env: ANSIBLE_VERSION=2.4.3.0
+    - os: osx
+      osx_image: xcode9.2
+      env: ANSIBLE_VERSION=2.4.3.0
+    - os: osx
+      osx_image: xcode9.2
+      env: ANSIBLE_VERSION=2.3.3.0
+    - os: osx
+      osx_image: xcode9.2
+      env: ANSIBLE_VERSION=2.2.3.0
+    - os: osx
+      osx_image: xcode8.3
+      env: ANSIBLE_VERSION=2.4.3.0
+    - os: osx
+      osx_image: xcode7.3
+      env: ANSIBLE_VERSION=2.4.3.0
+    - os: osx
+      osx_image: xcode6.4
+      env: ANSIBLE_VERSION=2.4.3.0
 
 branches:
   only:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
   platforms:
     - name: MacOSX
       versions:
+        - '10.13'
         - '10.12'
         - '10.11'
         - '10.10'


### PR DESCRIPTION
* Fix syntax for Travis CI test matrix, since env interpolation doesn't work
* Use xcode9.3beta (10.13) test env to the Travis CI matrix
* Add 10.13 to [meta/main.yml](meta/main.yml)