### PR TITLE
Beginning support for MacOS 10.13 (High Sierra)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9.3
-      env: ANSIBLE_VERSION=2.5.3
+      env: ANSIBLE_VERSION=2.5.4
     - os: osx
       osx_image: xcode9.3
       env: ANSIBLE_VERSION=2.4.4.0
@@ -17,16 +17,16 @@ matrix:
       env: ANSIBLE_VERSION=2.2.3.0
     - os: osx
       osx_image: xcode9.2
-      env: ANSIBLE_VERSION=2.5.3
+      env: ANSIBLE_VERSION=2.5.4
     - os: osx
       osx_image: xcode8.3
-      env: ANSIBLE_VERSION=2.5.3
+      env: ANSIBLE_VERSION=2.5.4
     - os: osx
       osx_image: xcode7.3
-      env: ANSIBLE_VERSION=2.5.3
+      env: ANSIBLE_VERSION=2.5.4
     - os: osx
       osx_image: xcode6.4
-      env: ANSIBLE_VERSION=2.5.3
+      env: ANSIBLE_VERSION=2.5.4
 
 branches:
   only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ pip install --no-deps -r tests/test-requirements.txt
 ```
 
 Run the full lifecycle test on a given `<PLATFORM>`. Allowed values for
-`<PLATFORM>` are `sierra`, `elcapitan`, and `yosemite`.
+`<PLATFORM>` are `highsierra`, `sierra`, `elcapitan`, and `yosemite`.
 
 ```bash
 source molecule/<PLATFORM>.sh

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,9 @@ platforms:
     box_version: ${MOLECULE_BOX_VERSION}
     memory: 2048
     cpus: 4
+    config_options:
+      synced_folder: false
+      boot_timeout: 300
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/highsierra.sh
+++ b/molecule/highsierra.sh
@@ -1,0 +1,3 @@
+export MOLECULE_NAME=highsierra
+export MOLECULE_BOX=monsenso/macos-10.13
+export MOLECULE_BOX_VERSION=1.1.0


### PR DESCRIPTION
This change facilitates stable testing of this role against
MacOS 10.13, which as of this change, is the most recent OS X version.

Addendum: Use Ansible 2.5.4 as most recent Ansible version in CI