### PR TITLE
Update requests library for version check test

### DIFF
--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -25,7 +25,7 @@ flake8==3.5.0
 funcsigs==1.0.2
 future==0.16.0
 git-url-parse==1.1.0
-idna==2.6
+idna==2.7
 ipaddress==1.0.22
 Jinja2==2.10
 jinja2-time==0.2.0
@@ -57,12 +57,12 @@ python-dateutil==2.7.3
 python-gilt==1.2.1
 python-vagrant==0.5.15
 PyYAML==3.12
-requests==2.18.4
+requests==2.19.0
 sh==1.12.14
 six==1.11.0
 tabulate==0.8.2
 testinfra==1.12.0
 tree-format==0.1.2
-urllib3==1.22
+urllib3==1.23
 whichcraft==0.4.1
 yamllint==1.11.1

--- a/tests/version_check.py
+++ b/tests/version_check.py
@@ -22,7 +22,7 @@ def main(argv):
     url = 'https://galaxy.ansible.com/api/v1/platforms/?name=MacOSX'
     r = requests.get(url)
     json_obj = json.loads(r.text)
-    allowed_versions = set(map(lambda x: str(x["release"]), json_obj))
+    allowed_versions = set(map(lambda x: str(x["release"]), json_obj['results']))
 
     print "ALLOWED:", list(allowed_versions)
     print


### PR DESCRIPTION
Galaxy changed its response payload when checking for available versions in a given platform. This change fixes the script which guarantees the `meta/main.yml` declares only valid versions. It also updates the `requests` library and its dependencies.