### PR TITLE
Fail task when software updates were not installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,3 +55,5 @@
   when: pkg_info.rc != 0 or compiler.rc != 0 or not clt.stat.exists
   notify:
     - Cleanup
+  register: su_result
+  failed_when: '"Error installing updates." in su_result.stdout'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,4 +56,4 @@
   notify:
     - Cleanup
   register: su_result
-  failed_when: '"Error installing updates." in su_result.stdout'
+  failed_when: 'su_result.rc != 0 or "Error installing updates." in su_result.stdout'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,4 +56,6 @@
   notify:
     - Cleanup
   register: su_result
-  failed_when: 'su_result.rc != 0 or "Error installing updates." in su_result.stdout'
+  failed_when: >-
+    su_result.rc != 0 or
+    'Error installing updates.' in su_result.stdout


### PR DESCRIPTION
I had a situation when `softwareupdate -i` resulted with 
```
Downloaded Command Line Tools (macOS High Sierra version 10.13) for Xcode\nDone.\n\nError installing updates.
```
in `stdout` with exit code 0, problem was hard to catch without the debug mode, because this task exited with success