### PR TITLE
Fix: Install the latest version of command line tools.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,8 @@
     grep -B 1 -E 'Command Line Tools' |
     awk -F'*' '/^ +\*/ {print $2}' |
     sed 's/^ *//' |
+    grep -iE '[0-9|.]' |
+    sort |
     tail -n1
   register: su_list
   when: pkg_info.rc != 0 or compiler.rc != 0 or not clt.stat.exists


### PR DESCRIPTION
The role should install the latest command line tools version for the latest os. Currently (on Mojave) this fails because the version 9.4 is installed where 10.0 is the correct one.