### PR TITLE
Fix for #55

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - pip --version
 
   # Setup virtualenv
-  - sudo -H pip install -U virtualenv
+  - sudo -H pip install -U virtualenv --ignore-installed six
   - virtualenv --version
   - virtualenv .venv
   - source .venv/bin/activate


### PR DESCRIPTION
* Add a flag to ignore installed six when installing Python modules with pip in Travis.
* Resolves #55 

A successful build can be found [here](https://travis-ci.com/github/martianplatypus/ansible-osx-command-line-tools/builds/159889761).
