### PR TITLE
Fix for #57

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ before_install:
   - URL=https://raw.githubusercontent.com/Homebrew/install/master/uninstall
   - curl -sLO "${URL}"
   - chmod +x uninstall
-  - ./uninstall --force
-  - rm -rf /usr/local/Homebrew
+  - yes | ./uninstall --force
+  - sudo rm -rf /usr/local/Homebrew
   - sudo rm -rf /usr/local/Caskroom
   - sudo rm -rf /usr/local/bin/brew
+  - sudo rm -rf /usr/local/Cellar
   - sudo rm -rf /Library/Developer/CommandLineTools
 
   # Install pip


### PR DESCRIPTION
**Issue**
Brew uninstall script prompts the user for confirmation before proceeding. This causes the build to hang while waiting for the user input.

**Changes**
* Calling the command line tool `yes` and piping with the script execution to prevent this issue.
* Travis user does not have permission to remove `/usr/local/Homebrew/` anymore. Added sudo to the command.
* Added a new entry in .travis.yml to remove `/usr/local/Cellar` manually. The uninstall script fails to remove this directory for the same reason mentioned above.

This pull request resolves #57.