### PR TITLE
Add a variable to timeout for softwareupdate calls

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,10 @@
 # defaults file for ansible-osx-command-line-tools
 
 force_install: no
+
+# How long to wait before timing out when calling the softwareupdate tool, in seconds.
+# When defined to 0 (the default value), no timeout is applied.
+# Depending on network conditions, Apple's service status, disk usage on the host, etc.,
+# the softwareupdate tool may timeout. Commonly, rebooting or resetting certain settings
+# on the host can fix this, but that is beyond the responsibility of this role.
+softwareupdate_timeout: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
     tail -n1
   args:
     executable: /bin/bash
+  timeout: "{{ softwareupdate_timeout }}"
   register: su_list_old
   when:
     - ansible_distribution_version is version('10.15', '<')
@@ -69,6 +70,7 @@
     tail -n1
   args:
     executable: /bin/bash
+  timeout: "{{ softwareupdate_timeout }}"
   register: su_list_new
   when:
     - ansible_distribution_version is version('10.15', '>=')
@@ -88,6 +90,7 @@
 
 - name: Install Command Line Tools
   command: softwareupdate -i '{{ su_list.stdout }}'
+  timeout: "{{ softwareupdate_timeout }}"
   when: pkg_info.rc != 0 or xcode_select.rc != 0 or not clt.stat.exists
   notify:
     - Cleanup


### PR DESCRIPTION
As the comment notes, the `softwareupdate` tool can hang for a variety of reasons. It would be nice to have a better workaround for this, but in the meantime we can at least fail these tasks and not cause the entire play to hang indefinitely.